### PR TITLE
Change license of repo to BSD-3-Clause

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-# This software may be modified and distributed under the terms of the
-# GNU Lesser General Public License v2.1 or any later version.
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.14)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,165 +1,28 @@
-                   GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+BSD 3-Clause License
 
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+Copyright (c) Fondazione Istituto Italiano di Tecnologia (IIT)
 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-  0. Additional Definitions.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
-
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
-
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
-
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
-
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
-
-  1. Exception to Section 3 of the GNU GPL.
-
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
-
-  2. Conveying Modified Versions.
-
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
-
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
-
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
-
-  3. Object Code Incorporating Material from Library Header Files.
-
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
-
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
-
-  4. Combined Works.
-
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
-
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
-
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
-
-   d) Do one of the following:
-
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
-
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
-
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
-
-  5. Combined Libraries.
-
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
-
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
-
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
-
-  6. Revised Versions of the GNU Lesser General Public License.
-
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
-
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
-
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cmake/AddSoftTerrainWalkingApplication.cmake
+++ b/cmake/AddSoftTerrainWalkingApplication.cmake
@@ -1,6 +1,6 @@
 # Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
-# This software may be modified and distributed under the terms of the
-# GNU Lesser General Public License v2.1 or any later version.
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 function(add_soft_terrain_walking_application)
 

--- a/cmake/AddSoftTerrainWalkingLibrary.cmake
+++ b/cmake/AddSoftTerrainWalkingLibrary.cmake
@@ -1,6 +1,6 @@
 # Copyright (C) 2022 Istituto Italiano di Tecnologia (IIT). All rights reserved.
-# This software may be modified and distributed under the terms of the
-# GNU Lesser General Public License v2.1 or any later version.
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 function(add_soft_terrain_walking_library)
 

--- a/cmake/InstallIniFiles.cmake
+++ b/cmake/InstallIniFiles.cmake
@@ -1,6 +1,6 @@
 # Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
-# This software may be modified and distributed under the terms of the
-# GNU Lesser General Public License v2.1 or any later version.
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 # List the subdirectory
 # http://stackoverflow.com/questions/7787823/cmake-how-to-get-the-name-of-all-subdirectories-of-a-directory

--- a/src/ContactModels/CMakeLists.txt
+++ b/src/ContactModels/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
-# This software may be modified and distributed under the terms of the
-# GNU Lesser General Public License v2.1 or any later version.
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 # set target name
 add_soft_terrain_walking_library(

--- a/src/ContactModels/include/SoftTerrainWalking/ContactModels/ContactModel.h
+++ b/src/ContactModels/include/SoftTerrainWalking/ContactModels/ContactModel.h
@@ -2,7 +2,7 @@
  * @file ContactModel.h
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef BIPEDAL_LOCOMOTION_CONTACT_MODELS_CONTACT_MODEL_H

--- a/src/ContactModels/include/SoftTerrainWalking/ContactModels/ContinuousContactModel.h
+++ b/src/ContactModels/include/SoftTerrainWalking/ContactModels/ContinuousContactModel.h
@@ -2,7 +2,7 @@
  * @file ContinuousContactModel.h
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_CONTACT_MODELS_CONTINUOUS_CONTACT_MODEL_H

--- a/src/ContactModels/src/ContactModel.cpp
+++ b/src/ContactModels/src/ContactModel.cpp
@@ -2,7 +2,7 @@
  * @file ContactModel.cpp
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <BipedalLocomotion/ContactModels/ContactModel.h>

--- a/src/ContactModels/src/ContinuousContactModel.cpp
+++ b/src/ContactModels/src/ContinuousContactModel.cpp
@@ -2,7 +2,7 @@
  * @file ContinuousContactModel.cpp
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <iDynTree/Core/EigenHelpers.h>

--- a/src/ContactModels/tests/ContinousContactModelTest.cpp
+++ b/src/ContactModels/tests/ContinousContactModelTest.cpp
@@ -2,7 +2,7 @@
  * @file ContinousContactModelTest.cpp
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <random>

--- a/src/OptimalControlUtilities/CMakeLists.txt
+++ b/src/OptimalControlUtilities/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
-# This software may be modified and distributed under the terms of the
-# GNU Lesser General Public License v2.1 or any later version.
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 set(H_PREFIX include/SoftTerrainWalking/OptimalControlUtilities)
 

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/CartesianElements.h
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/CartesianElements.h
@@ -2,7 +2,7 @@
  * @file CartesianElements.h
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_CARTESIAN_ELEMENT_H

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/CartesianElements.tpp
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/CartesianElements.tpp
@@ -2,7 +2,7 @@
  * @file CartesianElements.tpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <stdexcept>

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/CentroidalMomentumElements.h
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/CentroidalMomentumElements.h
@@ -2,7 +2,7 @@
  * @file CentroidalMomentumElements.h
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_CENTROIDAL_MOMENTUM_ELEMENT_H

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/CentroidalMomentumElementsWithCompliantContacts.h
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/CentroidalMomentumElementsWithCompliantContacts.h
@@ -2,7 +2,7 @@
  * @file CentroidalMomentumElementsWithCompliantContacts.h
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_CENTROIDAL_MOMENTUM_ELEMENT_WITH_COMPLIANT_CONTACT_H

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/CentroidalMomentumRateOfChangeBounds.h
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/CentroidalMomentumRateOfChangeBounds.h
@@ -2,7 +2,7 @@
  * @file CentroidalMomentumRateOfChangeBounds.h
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_CENTROIDAL_MOMENTUM_RATE_OF_CHANGE_BOUNDS

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/CentroidalMomentumRateOfChangeElements.h
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/CentroidalMomentumRateOfChangeElements.h
@@ -2,7 +2,7 @@
  * @file CentroidalMomentumRateOfChangeElements.h
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_CENTROIDAL_MOMENTUM_RATE_OF_CHANGE_ELEMENT

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/ContactModelElement.h
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/ContactModelElement.h
@@ -2,7 +2,7 @@
  * @file ContactModelElement.h
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_CONTACT_MODEL_ELEMENT_H

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/ContactWrenchFeasibilityElement.h
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/ContactWrenchFeasibilityElement.h
@@ -2,7 +2,7 @@
  * @file ContactWrenchFeasibilityElement.h
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_CONTACT_WRENCH_FEASIBILITY_ELEMENT_H

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/ControlProblemElements.h
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/ControlProblemElements.h
@@ -2,7 +2,7 @@
  * @file ControlProblemElements.h
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_CONTROL_PROBLEM_ELEMENTS_H

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/FeasibilityElements.h
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/FeasibilityElements.h
@@ -2,7 +2,7 @@
  * @file FeasibilityElements.h
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_FEASIBILITY_ELEMENT_H

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/FloatingBaseMultiBodyDynamicsElements.h
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/FloatingBaseMultiBodyDynamicsElements.h
@@ -2,7 +2,7 @@
  * @file FloatingBaseMultiBodyDynamicsElements.h
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_FLOATING_BASE_MULTI_BODY_DYNAMICS_ELEMENT_H

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/Frame.h
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/Frame.h
@@ -2,7 +2,7 @@
  * @file Frame.h
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_FRAME_H

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/Frame.tpp
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/Frame.tpp
@@ -2,7 +2,7 @@
  * @file Frame.tpp
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 namespace SoftTerrainWalking

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/OptimizationProblemElements.h
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/OptimizationProblemElements.h
@@ -2,7 +2,7 @@
  * @file OptimizationProblemElements.h
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_OPTIMIZATION_PROBLEM_ELEMENTS_H

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/PDController.h
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/PDController.h
@@ -2,7 +2,7 @@
  * @file PDController.h
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_PD_CONTROLLER_H

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/PDController.tpp
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/PDController.tpp
@@ -2,7 +2,7 @@
  * @file PDController.tpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <iDynTree/Core/EigenHelpers.h>

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/PIDController.h
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/PIDController.h
@@ -2,7 +2,7 @@
  * @file PIDController.h
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_PID_CONTROLLER_H

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/PIDController.tpp
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/PIDController.tpp
@@ -2,7 +2,7 @@
  * @file PDController.tpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <iDynTree/Core/EigenHelpers.h>

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/RegularizationElements.h
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/RegularizationElements.h
@@ -2,7 +2,7 @@
  * @file RegularizationElements.h
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_REGULARIZATION_ELEMENT_H

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/VariableHandler.h
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/VariableHandler.h
@@ -2,7 +2,7 @@
  * @file VariableHandler.h
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <string>

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/Weight.h
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/Weight.h
@@ -2,7 +2,7 @@
  * @file Weight.h
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_WEIGHT_H

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/Weight.tpp
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/Weight.tpp
@@ -2,7 +2,7 @@
  * @file Weight.tpp
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 namespace SoftTerrainWalking

--- a/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/ZMPElements.h
+++ b/src/OptimalControlUtilities/include/SoftTerrainWalking/OptimalControlUtilities/ZMPElements.h
@@ -2,7 +2,7 @@
  * @file ZMPElements.h
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_ZMP_ELEMENT_H

--- a/src/OptimalControlUtilities/src/CentroidalMomentumElements.cpp
+++ b/src/OptimalControlUtilities/src/CentroidalMomentumElements.cpp
@@ -2,7 +2,7 @@
  * @file CentroidalMomentumElements.cpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <iDynTree/Core/EigenHelpers.h>

--- a/src/OptimalControlUtilities/src/CentroidalMomentumElementsWithCompliantContacts.cpp
+++ b/src/OptimalControlUtilities/src/CentroidalMomentumElementsWithCompliantContacts.cpp
@@ -2,7 +2,7 @@
  * @file CentroidalMomentumElementsWithCompliantContacts.cpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <SoftTerrainWalking/OptimalControlUtilities/CentroidalMomentumElementsWithCompliantContacts.h>

--- a/src/OptimalControlUtilities/src/CentroidalMomentumRateOfChangeBounds.cpp
+++ b/src/OptimalControlUtilities/src/CentroidalMomentumRateOfChangeBounds.cpp
@@ -2,7 +2,7 @@
  * @file CentroidalMomentumRateOfChangeElements.cpp
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <SoftTerrainWalking/OptimalControlUtilities/CentroidalMomentumRateOfChangeBounds.h>

--- a/src/OptimalControlUtilities/src/CentroidalMomentumRateOfChangeElements.cpp
+++ b/src/OptimalControlUtilities/src/CentroidalMomentumRateOfChangeElements.cpp
@@ -2,7 +2,7 @@
  * @file CentroidalMomentumRateOfChangeElements.cpp
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <SoftTerrainWalking/OptimalControlUtilities/CentroidalMomentumRateOfChangeElements.h>

--- a/src/OptimalControlUtilities/src/ContactModelElement.cpp
+++ b/src/OptimalControlUtilities/src/ContactModelElement.cpp
@@ -2,7 +2,7 @@
  * @file ContactModelElement.cpp
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <SoftTerrainWalking/OptimalControlUtilities/ContactModelElement.h>

--- a/src/OptimalControlUtilities/src/ContactWrenchFeasibilityElement.cpp
+++ b/src/OptimalControlUtilities/src/ContactWrenchFeasibilityElement.cpp
@@ -2,7 +2,7 @@
  * @file ContactWrenchFeasibilityElement.cpp
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <stdexcept>

--- a/src/OptimalControlUtilities/src/ControlProblemElements.cpp
+++ b/src/OptimalControlUtilities/src/ControlProblemElements.cpp
@@ -2,7 +2,7 @@
  * @file ControlProblemElements.cpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <SoftTerrainWalking/OptimalControlUtilities/ControlProblemElements.h>

--- a/src/OptimalControlUtilities/src/FeasibilityElements.cpp
+++ b/src/OptimalControlUtilities/src/FeasibilityElements.cpp
@@ -2,7 +2,7 @@
  * @file FeasibilityElements.cpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <stdexcept>

--- a/src/OptimalControlUtilities/src/FloatingBaseMultiBodyDynamicsElements.cpp
+++ b/src/OptimalControlUtilities/src/FloatingBaseMultiBodyDynamicsElements.cpp
@@ -2,7 +2,7 @@
  * @file FloatingBaseMultiBodyDynamicsElements.cpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <stdexcept>

--- a/src/OptimalControlUtilities/src/OptimizationProblemElements.cpp
+++ b/src/OptimalControlUtilities/src/OptimizationProblemElements.cpp
@@ -2,7 +2,7 @@
  * @file OptimizationProblemElements.cpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <iDynTree/Core/EigenHelpers.h>

--- a/src/OptimalControlUtilities/src/PDController.cpp
+++ b/src/OptimalControlUtilities/src/PDController.cpp
@@ -2,7 +2,7 @@
  * @file PDController.cpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 // iDynTree

--- a/src/OptimalControlUtilities/src/RegularizationElements.cpp
+++ b/src/OptimalControlUtilities/src/RegularizationElements.cpp
@@ -2,7 +2,7 @@
  * @file RegularizationElements.cpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <stdexcept>

--- a/src/OptimalControlUtilities/src/VariableHandler.cpp
+++ b/src/OptimalControlUtilities/src/VariableHandler.cpp
@@ -2,7 +2,7 @@
  * @file VariableHandler.cpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <iostream>

--- a/src/OptimalControlUtilities/src/ZMPElements.cpp
+++ b/src/OptimalControlUtilities/src/ZMPElements.cpp
@@ -2,7 +2,7 @@
  * @file ZMPElements.cpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <stdexcept>

--- a/src/OptimalControlUtilities/tests/CMakeLists.txt
+++ b/src/OptimalControlUtilities/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
-# This software may be modified and distributed under the terms of the
-# GNU Lesser General Public License v2.1 or any later version.
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 if(SOFT_TERRAIN_WALKING_CONTROLLERS_COMPILE_tests)
 

--- a/src/OptimalControlUtilities/tests/ControlProblemTest.cpp
+++ b/src/OptimalControlUtilities/tests/ControlProblemTest.cpp
@@ -2,7 +2,7 @@
  * @file ControlProblemTest.cpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 // Catch2

--- a/src/OptimalControlUtilities/tests/ControlProblemTestMain.cpp
+++ b/src/OptimalControlUtilities/tests/ControlProblemTestMain.cpp
@@ -2,7 +2,7 @@
  * @file ControlProblemTestMain.cpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #define CATCH_CONFIG_MAIN

--- a/src/OptimalControlUtilities/tests/OptimizationProblemTest.cpp
+++ b/src/OptimalControlUtilities/tests/OptimizationProblemTest.cpp
@@ -2,7 +2,7 @@
  * @file OptimizationProblemTest.cpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 // Catch2

--- a/src/OptimalControlUtilities/tests/OptimizationProblemTestMain.cpp
+++ b/src/OptimalControlUtilities/tests/OptimizationProblemTestMain.cpp
@@ -2,7 +2,7 @@
  * @file OptimizationProblemTestMain.cpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #define CATCH_CONFIG_MAIN

--- a/src/OptimalControlUtilities/tests/VariableHandlerTest.cpp
+++ b/src/OptimalControlUtilities/tests/VariableHandlerTest.cpp
@@ -2,7 +2,7 @@
  * @file ControlProblemTest.cpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 // Catch2

--- a/src/OptimalControlUtilities/tests/VariableHandlerTestMain.cpp
+++ b/src/OptimalControlUtilities/tests/VariableHandlerTestMain.cpp
@@ -2,7 +2,7 @@
  * @file VariableHandlerTestMain.cpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #define CATCH_CONFIG_MAIN

--- a/src/OptimalControlUtilitiesRigid/include/SoftTerrainWalking/OptimalControlUtilitiesRigid/ControlProblemElements.h
+++ b/src/OptimalControlUtilitiesRigid/include/SoftTerrainWalking/OptimalControlUtilitiesRigid/ControlProblemElements.h
@@ -1,7 +1,7 @@
 /**
  * @file ControlProblemElements.h
  * @authors Giulio Romualdi
- * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_RIGID_CONTROL_PROBLEM_ELEMENTS_H

--- a/src/OptimalControlUtilitiesRigid/include/SoftTerrainWalking/OptimalControlUtilitiesRigid/OptimizationProblemElements.h
+++ b/src/OptimalControlUtilitiesRigid/include/SoftTerrainWalking/OptimalControlUtilitiesRigid/OptimizationProblemElements.h
@@ -1,7 +1,7 @@
 /**
  * @file OptimizationProblemElements.h
  * @authors Giulio Romualdi
- * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_RIGID_OPTIMIZATION_PROBLEM_ELEMENTS_H

--- a/src/OptimalControlUtilitiesRigid/include/SoftTerrainWalking/OptimalControlUtilitiesRigid/PID.h
+++ b/src/OptimalControlUtilitiesRigid/include/SoftTerrainWalking/OptimalControlUtilitiesRigid/PID.h
@@ -1,7 +1,7 @@
 /**
  * @file PID.h
  * @authors Giulio Romualdi
- * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_OPTIMAL_CONTROL_UTILITIES_RIGID_PID_H

--- a/src/OptimalControlUtilitiesRigid/include/SoftTerrainWalking/OptimalControlUtilitiesRigid/VariableHandler.h
+++ b/src/OptimalControlUtilitiesRigid/include/SoftTerrainWalking/OptimalControlUtilitiesRigid/VariableHandler.h
@@ -1,7 +1,7 @@
 /**
  * @file VariableHandler.h
  * @authors Giulio Romualdi
- * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <string>

--- a/src/OptimalControlUtilitiesRigid/src/PID.cpp
+++ b/src/OptimalControlUtilitiesRigid/src/PID.cpp
@@ -2,7 +2,7 @@
  * @file PID.cpp
  * @authors Giulio Romualdi
  * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 // iDynTree

--- a/src/OptimalControlUtilitiesRigid/src/VariableHandler.cpp
+++ b/src/OptimalControlUtilitiesRigid/src/VariableHandler.cpp
@@ -1,7 +1,7 @@
 /**
  * @file VariableHandler.cpp
  * @authors Giulio Romualdi
- * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * @copyright 2019 Istituto Italiano di Tecnologia (IIT). This software may be modified and distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <iostream>

--- a/src/Simulator/CMakeLists.txt
+++ b/src/Simulator/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
-# This software may be modified and distributed under the terms of the
-# GNU Lesser General Public License v2.1 or any later version.
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 # set target name
 

--- a/src/Simulator/include/SoftTerrainWalking/Simulator/Plane.h
+++ b/src/Simulator/include/SoftTerrainWalking/Simulator/Plane.h
@@ -2,7 +2,7 @@
  * @file Plane.h
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_SIMULATOR_PLANE_H

--- a/src/Simulator/include/SoftTerrainWalking/Simulator/Simulator.h
+++ b/src/Simulator/include/SoftTerrainWalking/Simulator/Simulator.h
@@ -2,7 +2,7 @@
  * @file Simulator.h
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_SIMULATOR_SIMULATOR_H

--- a/src/Simulator/include/SoftTerrainWalking/Simulator/Visualizer.h
+++ b/src/Simulator/include/SoftTerrainWalking/Simulator/Visualizer.h
@@ -2,7 +2,7 @@
  * @file Visualizer.h
  * @authors Stefano Dafarra Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #ifndef SOFT_TERRAIN_WALKING_SIMULATOR_VISUALIZER_H

--- a/src/Simulator/src/Simulator.cpp
+++ b/src/Simulator/src/Simulator.cpp
@@ -2,7 +2,7 @@
  * @file Simulator.cpp
  * @authors Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 #include <BipedalLocomotion/ContinuousDynamicalSystem/CompliantContactWrench.h>

--- a/src/Simulator/src/Visualizer.cpp
+++ b/src/Simulator/src/Visualizer.cpp
@@ -2,7 +2,7 @@
  * @file Visualizer.h
  * @authors Stefano Dafarra Giulio Romualdi
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  */
 
 // std

--- a/src/WholeBodyControllers/CMakeLists.txt
+++ b/src/WholeBodyControllers/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2019 Istituto Italiano di Tecnologia (IIT). All rights reserved.
-# This software may be modified and distributed under the terms of the
-# GNU Lesser General Public License v2.1 or any later version.
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
 
 set(H_PREFIX include/SoftTerrainWalking/WholeBodyControllers)
 

--- a/src/WholeBodyControllers/include/SoftTerrainWalking/WholeBodyControllers/MomentumBasedControl.h
+++ b/src/WholeBodyControllers/include/SoftTerrainWalking/WholeBodyControllers/MomentumBasedControl.h
@@ -2,7 +2,7 @@
  * @file MomentumBasedControl.h
  * @authors Giulio Romualdi <giulio.romualdi@iit.it>
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  * @date 2020
  */
 

--- a/src/WholeBodyControllers/include/SoftTerrainWalking/WholeBodyControllers/MomentumBasedControlHelper.h
+++ b/src/WholeBodyControllers/include/SoftTerrainWalking/WholeBodyControllers/MomentumBasedControlHelper.h
@@ -2,7 +2,7 @@
  * @file MomentumBasedControlHelper.h
  * @authors Giulio Romualdi <giulio.romualdi@iit.it>
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  * @date 2020
  */
 

--- a/src/WholeBodyControllers/include/SoftTerrainWalking/WholeBodyControllers/MomentumBasedControlHelper.tpp
+++ b/src/WholeBodyControllers/include/SoftTerrainWalking/WholeBodyControllers/MomentumBasedControlHelper.tpp
@@ -2,7 +2,7 @@
  * @file MomentumBasedTorqueControl.tpp
  * @authors Giulio Romualdi <giulio.romualdi@iit.it>
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  * @date 2020
  */
 

--- a/src/WholeBodyControllers/src/MomentumBasedControl.cpp
+++ b/src/WholeBodyControllers/src/MomentumBasedControl.cpp
@@ -2,7 +2,7 @@
  * @file MomentumBasedControl.cpp
  * @authors Giulio Romualdi <giulio.romualdi@iit.it>
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  * @date 2020
  */
 

--- a/src/WholeBodyControllers/src/MomentumBasedControlHelper.cpp
+++ b/src/WholeBodyControllers/src/MomentumBasedControlHelper.cpp
@@ -2,7 +2,7 @@
  * @file MomentumBasedControlHelper.cpp
  * @authors Giulio Romualdi <giulio.romualdi@iit.it>
  * @copyright 2020 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the GNU Lesser General Public License v2.1 or any later version.
+ * distributed under the terms of the BSD-3-Clause license.
  * @date 2020
  */
 


### PR DESCRIPTION
We are trying to uniform all ami-iit repos to use BSD-3-Clause, see https://github.com/robotology/idyntree/pull/1089 .